### PR TITLE
feat!: collect email addresses of discord users

### DIFF
--- a/subm/package.json
+++ b/subm/package.json
@@ -41,6 +41,7 @@
     "express": "^4.17.1",
     "express-session": "^1.17.2",
     "firebase-admin": "^9.11.0",
+    "google-spreadsheet": "^3.2.0",
     "passport": "^0.4.1",
     "passport-discord": "^0.1.4"
   },

--- a/subm/src/config.js
+++ b/subm/src/config.js
@@ -1,0 +1,17 @@
+/**
+ * @param { NodeJS.ProcessEnv } env
+ * @returns { TemplateTag }
+ * @typedef { (parts: TemplateStringsArray, ...args: unknown[]) => string } TemplateTag
+ */
+const makeConfig = env => {
+  return ([name], ..._args) => {
+    const value = env[name];
+    if (value === undefined) {
+      throw Error(`${name} not configured`);
+    }
+    return value;
+  };
+};
+
+/* global exports */
+exports.makeConfig = makeConfig;

--- a/subm/src/discordGuild.js
+++ b/subm/src/discordGuild.js
@@ -1,5 +1,6 @@
 /* global Buffer */
 // @ts-check
+const { makeConfig } = require('./config.js');
 
 const { entries, freeze } = Object;
 
@@ -156,21 +157,6 @@ async function pagedMembers(guild) {
   } while (after);
   return pages.flat();
 }
-
-/**
- * @param { NodeJS.ProcessEnv } env
- * @returns { TemplateTag }
- * @typedef { (parts: TemplateStringsArray, ...args: unknown[]) => string } TemplateTag
- */
-const makeConfig = env => {
-  return ([name], ..._args) => {
-    const value = env[name];
-    if (value === undefined) {
-      throw Error(`${name} not configured`);
-    }
-    return value;
-  };
-};
 
 /**
  * @param {Record<string, string | undefined>} env

--- a/subm/src/firebaseTool.js
+++ b/subm/src/firebaseTool.js
@@ -1,5 +1,6 @@
 /* global Buffer */
 // @ts-check
+const { makeConfig } = require('./config.js');
 
 const { freeze } = Object; // IOU ses / harden
 
@@ -44,21 +45,6 @@ function makeFirebaseAdmin(admin, firebaseConfig) {
     },
   });
 }
-
-/**
- * @param { NodeJS.ProcessEnv } env
- * @returns { TemplateTag }
- * @typedef { (parts: TemplateStringsArray, ...args: unknown[]) => string } TemplateTag
- */
-const makeConfig = env => {
-  return ([name], ..._args) => {
-    const value = env[name];
-    if (value === undefined) {
-      throw Error(`${name} not configured`);
-    }
-    return value;
-  };
-};
 
 /**
  * @param {string[]} args

--- a/subm/src/sheetAccess.js
+++ b/subm/src/sheetAccess.js
@@ -53,7 +53,10 @@ const main = async (argv, env, { GoogleSpreadsheet }) => {
   // Initialize the sheet - doc ID is the long id in the sheets URL
   const doc = new GoogleSpreadsheet(env.SHEET1_ID);
 
-  const creds = JSON.parse(env.GCS_SERVICE_ACCOUNT);
+  const creds = {
+    client_email: env.GOOGLE_SERVICES_EMAIL,
+    private_key: env.GCS_PRIVATE_KEY,
+  };
   // Initialize Auth - see https://theoephraim.github.io/node-google-spreadsheet/#/getting-started/authentication
   await doc.useServiceAccountAuth(creds);
 

--- a/subm/src/sheetAccess.js
+++ b/subm/src/sheetAccess.js
@@ -1,5 +1,39 @@
+const range = n => [...Array(n).keys()];
+const takeWhile = (xs, predicate) =>
+  xs.slice(
+    0,
+    xs.findIndex(x => !predicate(x)),
+  );
+
 /**
- *
+ * @param {import('google-spreadsheet').GoogleSpreadsheetWorksheet} sheet
+ * @param {string | number} key
+ * @param {Record<string, string | number>} record
+ */
+const upsert = async (sheet, key, record) => {
+  // load primary key column
+  await sheet.loadCells({
+    startColumnIndex: 0,
+    endColumnIndex: 1,
+  });
+
+  const destIndex = range(sheet.rowCount).find(rowIndex => {
+    if (rowIndex === 0) return false; // header row
+    const { value } = sheet.getCell(rowIndex, 0);
+    return key === value || value === null;
+  });
+  if (destIndex < 0) throw Error('key not found and no available rows');
+  let [row] = await sheet.getRows({ offset: destIndex - 1, limit: 1 });
+  if (row) {
+    Object.assign(row, record);
+    await row.save({ raw: true });
+  } else {
+    row = await sheet.addRow(record);
+  }
+  return row;
+};
+
+/**
  * @param {string[]} argv
  * @param {Record<string, string | undefined>} env
  * @param {Object} io
@@ -7,7 +41,7 @@
  */
 const main = async (argv, env, { GoogleSpreadsheet }) => {
   // Initialize the sheet - doc ID is the long id in the sheets URL
-  const doc = new GoogleSpreadsheet(env.SHEET1_ID); // ISSUE: AMBIENT
+  const doc = new GoogleSpreadsheet(env.SHEET1_ID);
 
   const creds = JSON.parse(env.GCS_SERVICE_ACCOUNT);
   // Initialize Auth - see https://theoephraim.github.io/node-google-spreadsheet/#/getting-started/authentication
@@ -15,15 +49,15 @@ const main = async (argv, env, { GoogleSpreadsheet }) => {
 
   await doc.loadInfo(); // loads document properties and worksheets
   console.log(doc.title);
-  //   await doc.updateProperties({ title: 'renamed doc' });
 
-  //   const sheet = doc.sheetsByIndex[0]; // or use doc.sheetsById[id] or doc.sheetsByTitle[title]
-  //   console.log(sheet.title);
-  //   console.log(sheet.rowCount);
+  const sheet = doc.sheetsByIndex[0]; // or use doc.sheetsById[id] or doc.sheetsByTitle[title]
+  console.log(sheet.title);
+  console.log(sheet.rowCount);
 
-  //   // adding / removing sheets
-  //   const newSheet = await doc.addSheet({ title: 'hot new sheet!' });
-  //   await newSheet.delete();
+  await upsert(sheet, '358096357862408195', {
+    userID: '358096357862408195',
+    email: 'dckc@agoric.com',
+  });
 };
 
 /* global require, process, module */

--- a/subm/src/sheetAccess.js
+++ b/subm/src/sheetAccess.js
@@ -1,0 +1,39 @@
+/**
+ *
+ * @param {string[]} argv
+ * @param {Record<string, string | undefined>} env
+ * @param {Object} io
+ * @param {typeof import('google-spreadsheet').GoogleSpreadsheet} io.GoogleSpreadsheet
+ */
+const main = async (argv, env, { GoogleSpreadsheet }) => {
+  // Initialize the sheet - doc ID is the long id in the sheets URL
+  const doc = new GoogleSpreadsheet(env.SHEET1_ID); // ISSUE: AMBIENT
+
+  const creds = JSON.parse(env.GCS_SERVICE_ACCOUNT);
+  // Initialize Auth - see https://theoephraim.github.io/node-google-spreadsheet/#/getting-started/authentication
+  await doc.useServiceAccountAuth(creds);
+
+  await doc.loadInfo(); // loads document properties and worksheets
+  console.log(doc.title);
+  //   await doc.updateProperties({ title: 'renamed doc' });
+
+  //   const sheet = doc.sheetsByIndex[0]; // or use doc.sheetsById[id] or doc.sheetsByTitle[title]
+  //   console.log(sheet.title);
+  //   console.log(sheet.rowCount);
+
+  //   // adding / removing sheets
+  //   const newSheet = await doc.addSheet({ title: 'hot new sheet!' });
+  //   await newSheet.delete();
+};
+
+/* global require, process, module */
+if (require.main === module) {
+  main(
+    process.argv.slice(2),
+    { ...process.env },
+    {
+      // eslint-disable-next-line global-require
+      GoogleSpreadsheet: require('google-spreadsheet').GoogleSpreadsheet, // please excuse CJS
+    },
+  ).catch(err => console.error(err));
+}

--- a/subm/src/sheetAccess.js
+++ b/subm/src/sheetAccess.js
@@ -1,9 +1,4 @@
 const range = n => [...Array(n).keys()];
-const takeWhile = (xs, predicate) =>
-  xs.slice(
-    0,
-    xs.findIndex(x => !predicate(x)),
-  );
 
 /**
  * @param {GoogleSpreadsheetWorksheet} sheet

--- a/subm/src/subm.js
+++ b/subm/src/subm.js
@@ -318,6 +318,7 @@ function makeContact(sheet, member) {
         fullName,
         countryOfResidence,
         interestInAgoric,
+        agreeToBeContacted,
         agreeToReceiveNewsletter,
       } = row;
       return {
@@ -325,6 +326,7 @@ function makeContact(sheet, member) {
         fullName,
         countryOfResidence,
         interestInAgoric,
+        agreeToBeContacted,
         agreeToReceiveNewsletter,
       };
     },
@@ -592,6 +594,7 @@ async function main(
       fullName,
       countryOfResidence,
       interestInAgoric,
+      agreeToBeContacted,
       agreeToReceiveNewsletter,
     } = req.body;
     if (typeof email !== 'string') throw TypeError(email);
@@ -600,6 +603,7 @@ async function main(
       fullName,
       countryOfResidence,
       interestInAgoric,
+      agreeToBeContacted,
       agreeToReceiveNewsletter,
     });
     res.redirect(`${Site.path.contactForm}?ack=1`);

--- a/subm/src/subm.js
+++ b/subm/src/subm.js
@@ -464,7 +464,11 @@ async function main(
   );
 
   const doc = new GoogleSpreadsheet(config`SHEET1_ID`);
-  await doc.useServiceAccountAuth(JSON.parse(config`GCS_SERVICE_ACCOUNT`));
+
+  await doc.useServiceAccountAuth({
+    client_email: config`GOOGLE_SERVICES_EMAIL`,
+    private_key: config`GCS_PRIVATE_KEY`,
+  });
   await doc.loadInfo();
 
   const discordAPI = DiscordAPI(config`DISCORD_API_TOKEN`, { get });

--- a/subm/src/subm.js
+++ b/subm/src/subm.js
@@ -194,8 +194,8 @@ ${Site.welcome(member)}
     <label>I agree to receive the Agoric Newsletter to keep me updated on Agoric progress and news:
     ${Site.yesNo('agreeToReceiveNewsletter', agreeToReceiveNewsletter)}</label>
     <input type="submit" value="Submit">
+    ${ack ? `<p><b>Contact info updated. Thank you.</b></p>` : ''}
   </fieldset>
-  ${ack ? `<p><b>Contact info updated. Thank you.</b></p>` : ''}
 </form>
   `,
   /**

--- a/subm/src/subm.js
+++ b/subm/src/subm.js
@@ -18,6 +18,7 @@ const { DiscordAPI, avatar } = require('./discordGuild.js');
 const { makeFirebaseAdmin, getFirebaseConfig } = require('./firebaseTool.js');
 const { generateV4SignedPolicy } = require('./objStore.js');
 const { lookup, upsert } = require('./sheetAccess.js');
+const { makeConfig } = require('./config.js');
 
 const { freeze, keys, values, entries } = Object; // please excuse freeze vs. harden
 
@@ -473,21 +474,6 @@ function makeDiscordBot(guild, authorizedRoles, opts, powers) {
 
   return self;
 }
-
-/**
- * @param { NodeJS.ProcessEnv } env
- * @returns { TemplateTag }
- * @typedef { (parts: TemplateStringsArray, ...args: unknown[]) => string } TemplateTag
- */
-const makeConfig = env => {
-  return ([name], ..._args) => {
-    const value = env[name];
-    if (value === undefined) {
-      throw Error(`${name} not configured`);
-    }
-    return value;
-  };
-};
 
 /**
  * @param { NodeJS.ProcessEnv } env

--- a/subm/src/subm.js
+++ b/subm/src/subm.js
@@ -182,14 +182,14 @@ ${Site.welcome(member)}
   <fieldset><legend>Contact Info</legend>
     <label>Email: <input name="email" type="email"
      value="${email || ''}"/></label>
-    <label>First and Last Name: <input name="fullName"
+    <label>Full Name: <input name="fullName"
      value="${fullName || ''}"/></label>
-    <label>Country of residence: <input name="countryOfResidence"
-     value="${countryOfResidence || ''}"/></label>
     <label>Briefly describe your interest in Agoric:<br />
      <textarea name="interestInAgoric" rows="6" columns="60">${interestInAgoric ||
        ''}</textarea>
       </label>
+    <label>Country of residence: <input name="countryOfResidence"
+      value="${countryOfResidence || ''}"/></label>
     <label>I agree to be contacted by Agoric regarding opportunities:
      ${Site.yesNo('agreeToBeContacted', agreeToBeContacted)}</label>
     <label>I agree to receive the Agoric Newsletter to keep me updated on Agoric progress and news:

--- a/subm/src/subm.js
+++ b/subm/src/subm.js
@@ -535,7 +535,7 @@ async function main(
     const { email } = req.body;
     if (typeof email !== 'string') throw TypeError(email);
     await contact.setEmail(email);
-    res.redirect(''); // same page
+    res.redirect(Site.path.contactForm);
   });
 
   // Upload form

--- a/subm/src/subm.js
+++ b/subm/src/subm.js
@@ -267,15 +267,14 @@ function makeContact(sheet, member) {
     /**
      * @param {string} email
      */
-    setEmail: email => {
+    setEmail: email =>
       upsert(sheet, user.id, {
         userID: user.id,
         joined_at: member.joined_at,
         nick: member.nick || '<nick???>',
         email,
         detail: JSON.stringify(member, null, 2),
-      });
-    },
+      }),
   });
 }
 
@@ -499,6 +498,7 @@ async function main(
   );
   app.use(aPassport.initialize());
   app.use(aPassport.session());
+  app.use(express.urlencoded({ extended: true }));
   app.get(Site.path.login, loginHandler);
   app.get(
     Site.path.callback,
@@ -529,6 +529,13 @@ async function main(
     }
     const page = Site.contactForm(contact.member, email);
     res.send(page);
+  });
+  app.post(Site.path.contactForm, loginCheck, async (req, res) => {
+    const contact = /** @type { ReturnType<typeof makeContact> } */ (req.user);
+    const { email } = req.body;
+    if (typeof email !== 'string') throw TypeError(email);
+    await contact.setEmail(email);
+    res.redirect(''); // same page
   });
 
   // Upload form

--- a/subm/src/subm.js
+++ b/subm/src/subm.js
@@ -135,7 +135,9 @@ const Site = freeze({
   welcome: member => `
     <figure>
     <img class="avatar" src="${avatar(member.user)}" />
-    <figcaption>Welcome <b>${member.nick || 'participant'}</b>.</figcaption>
+    <figcaption>Welcome <b>${member.nick ||
+      (member.user || {}).username ||
+      'participant'}</b>.</figcaption>
     </figure>
   `,
 
@@ -271,7 +273,7 @@ function makeContact(sheet, member) {
       upsert(sheet, user.id, {
         userID: user.id,
         joined_at: member.joined_at,
-        nick: member.nick || '<nick???>',
+        nick: member.nick || (member.user || {}).username || '<nick???>',
         email,
         detail: JSON.stringify(member, null, 2),
       }),

--- a/subm/src/subm.js
+++ b/subm/src/subm.js
@@ -307,10 +307,12 @@ function makeContact(sheet, member) {
   if (!user) throw TypeError('user undefined');
   return freeze({
     member,
-    /** @returns { Promise<ContactInfo> } */
+    /**
+     * @returns { Promise<ContactInfo> }
+     * @throws on not found
+     */
     getContactInfo: async () => {
       const row = await lookup(sheet, user.id);
-      if (!row) throw RangeError(user.id);
       const {
         email,
         fullName,

--- a/subm/src/subm.js
+++ b/subm/src/subm.js
@@ -17,6 +17,7 @@ const { DiscordAPI, avatar } = require('./discordGuild.js');
 /** @typedef { import('./discordGuild.js').GuildMember } GuildMember */
 const { makeFirebaseAdmin, getFirebaseConfig } = require('./firebaseTool.js');
 const { generateV4SignedPolicy } = require('./objStore.js');
+const { lookup, upsert } = require('./sheetAccess.js');
 
 const { freeze, keys, values, entries } = Object; // please excuse freeze vs. harden
 
@@ -27,7 +28,7 @@ const AgoricStyle = freeze({
   top: `
   <!doctype html>
   <head>
-  <title>Agoric Testnet Submission</title>
+  <title>Agoric Submission Tool</title>
   <style>
     label { display: block; padding: .5em }
     .avatar {
@@ -44,7 +45,7 @@ const AgoricStyle = freeze({
   <a href="https://agoric.com/"
   ><img alt="Agoric" align="bottom"
      src="https://agoric.com/wp-content/themes/agoric_2021_theme/assets/img/logo.svg"
-      /></a> &middot; <a href="https://validate.agoric.com/">Incentivized Testnet</a>
+      /></a>
   <br />
   <hr />
   <address>
@@ -59,6 +60,7 @@ const Site = freeze({
     login: '/auth/discord',
     callback: '/auth/discord/callback',
     badLogin: '/loginRefused',
+    contactForm: '/community/contact',
     uploadSlog: '/participant/slogForm',
     uploadSuccess: '/participant/slogOK',
     loadGenKey: '/participant/loadGenKey',
@@ -89,7 +91,19 @@ const Site = freeze({
   },
 
   start: () => `${AgoricStyle.top}
-<h1>Incentivized Testnet Participants</h1>
+<h2>Community Participants</h1>
+
+<form action="/auth/discord">
+<fieldset>
+<legend>To Submit Contact Info</legend>
+<large>
+<button type="submit">Login via Discord</button>
+</large>
+</fieldset>
+</form>
+</div>
+
+<h2>Incentivized Testnet Participants</h1>
 
 <form action="/auth/discord">
 <fieldset>
@@ -104,13 +118,16 @@ const Site = freeze({
 
   testnetRoles: {
     'testnet-participant': '819067161371738173',
+    Community: '757035496198111262',
     // TODO: support for many-to-one discord to moniker
     // 'testnet-teammate': '825108158744756226',
     team: '754111409645682700',
   },
 
   badLogin: () => `${AgoricStyle.top}
-  <p><strong>Login refused.</strong> Only Incentivized Testnet participants are allowed.</p>
+  <p><strong>Login refused.</strong> Only ${keys(Site.testnetRoles).join(
+    '/',
+  )} members are allowed.</p>
   <form action="/"><button type="submit">Try again</button></form>
   `,
 
@@ -122,6 +139,24 @@ const Site = freeze({
     </figure>
   `,
 
+  /**
+   * @param { GuildMember } member
+   * @param { string | undefined } email
+   */
+  contactForm: (member, email) => `${AgoricStyle.top}
+
+<h1>Contact Info</h1>
+
+${Site.welcome(member)}
+
+<form method="POST" >
+  <fieldset><legend>Email Address</legend>
+    <label>Email: <input name="email" type="email"
+     value="${email || ''}"/></label>
+    <input type="submit" value="Submit">
+  </fieldset>
+</form>
+  `,
   /**
    * @param { GuildMember } member
    * @param { string } combinedToken
@@ -214,6 +249,37 @@ ${Site.fileList(files)}
 });
 
 /**
+ * @param {GoogleSpreadsheetWorksheet} sheet
+ * @param {GuildMember} member
+ */
+function makeContact(sheet, member) {
+  const { user } = member;
+  if (!user) throw TypeError('user undefined');
+  return freeze({
+    member,
+    getEmail: async () => {
+      const row = await lookup(sheet, user.id);
+      if (!row) return undefined;
+      if (typeof row.email !== 'string') throw TypeError(row.email);
+      return row.email;
+    },
+
+    /**
+     * @param {string} email
+     */
+    setEmail: email => {
+      upsert(sheet, user.id, {
+        userID: user.id,
+        joined_at: member.joined_at,
+        nick: member.nick || '<nick???>',
+        email,
+        detail: JSON.stringify(member, null, 2),
+      });
+    },
+  });
+}
+
+/**
  * @param {GuildMember} member
  * @param { string } bucket
  * @param { StorageT } objectStore
@@ -265,7 +331,9 @@ function makeTestnetParticipant(member, bucket, objectStore, loadGenAdmin) {
  * @param { StorageT } powers.objectStore
  * @param { string } powers.bucketName
  * @param { FirebaseAdmin } powers.loadGenAdmin
+ * @param { GoogleSpreadsheetWorksheet } powers.contactSheet
  * @typedef {import('./discordGuild.js').Snowflake} Snowflake
+ * @typedef { import('google-spreadsheet').GoogleSpreadsheetWorksheet} GoogleSpreadsheetWorksheet
  */
 function makeDiscordBot(guild, authorizedRoles, opts, powers) {
   /** @param { GuildMember } mem */
@@ -278,13 +346,22 @@ function makeDiscordBot(guild, authorizedRoles, opts, powers) {
   };
 
   /** @param { GuildMember } member */
-  const reviveMember = member =>
-    makeTestnetParticipant(
-      member,
-      powers.bucketName,
-      powers.objectStore,
-      powers.loadGenAdmin,
-    );
+  const reviveMember = member => {
+    // ISSUE: make testnet participant powers available based on role.
+    // eslint-disable-next-line no-constant-condition
+    const tester = false
+      ? makeTestnetParticipant(
+          member,
+          powers.bucketName,
+          powers.objectStore,
+          powers.loadGenAdmin,
+        )
+      : {};
+    return freeze({
+      ...makeContact(powers.contactSheet, member),
+      ...tester,
+    });
+  };
 
   const self = freeze({
     /** @param {string} failureRedirect */
@@ -357,12 +434,16 @@ const makeConfig = env => {
  *   clock: () => number,
  *   get: typeof import('https').get,
  *   express: typeof import('express'),
+ *   GoogleSpreadsheet: typeof import('google-spreadsheet').GoogleSpreadsheet,
  *   makeStorage: (...args: unknown[]) => StorageT,
  *   admin: typeof import('firebase-admin')
  * }} io
  * @typedef { import('@google-cloud/storage').Storage } StorageT
  */
-async function main(env, { clock, get, express, makeStorage, admin }) {
+async function main(
+  env,
+  { clock, get, express, makeStorage, admin, GoogleSpreadsheet },
+) {
   const app = express();
   app.enable('trust proxy'); // trust X-Forwarded-* headers
   app.get('/', (_req, res) => res.send(Site.start()));
@@ -382,6 +463,10 @@ async function main(env, { clock, get, express, makeStorage, admin }) {
     }),
   );
 
+  const doc = new GoogleSpreadsheet(config`SHEET1_ID`);
+  await doc.useServiceAccountAuth(JSON.parse(config`GCS_SERVICE_ACCOUNT`));
+  await doc.loadInfo();
+
   const discordAPI = DiscordAPI(config`DISCORD_API_TOKEN`, { get });
   const guild = discordAPI.guilds(config`DISCORD_GUILD_ID`);
   const loadGenAdmin = makeFirebaseAdmin(admin, getFirebaseConfig(config));
@@ -400,6 +485,7 @@ async function main(env, { clock, get, express, makeStorage, admin }) {
       // ASSUME we are running in an environment which supports Application Default Credentials
       objectStore: makeStorage(),
       loadGenAdmin,
+      contactSheet: doc.sheetsByIndex[0],
     },
   );
 
@@ -413,7 +499,7 @@ async function main(env, { clock, get, express, makeStorage, admin }) {
   app.get(
     Site.path.callback,
     callbackHandler,
-    (_req, res) => res.redirect(Site.path.uploadSlog), // Successful auth
+    (_req, res) => res.redirect(Site.path.contactForm), // Successful auth. ISSUE: slogForm
   );
   app.get(Site.path.badLogin, (_r, res) => res.send(Site.badLogin()));
 
@@ -427,23 +513,41 @@ async function main(env, { clock, get, express, makeStorage, admin }) {
       error: app.get('env') === 'development' ? err : {},
     });
   };
+
+  app.get(Site.path.contactForm, loginCheck, async (req, res) => {
+    const contact = /** @type { ReturnType<typeof makeContact> } */ (req.user);
+    const { user } = contact.member;
+    if (!user) throw Error('no user');
+    const detail = await discordAPI.users(user.id);
+    let email = detail.email; // ISSUE: why is email missing? what bot permission am I missing?
+    if (!email) {
+      email = await contact.getEmail();
+    }
+    const page = Site.contactForm(contact.member, email);
+    res.send(page);
+  });
+
   // Upload form
   // Note the actual upload request goes directly to Google Cloud Storage.
-  app.get(Site.path.uploadSlog, loginCheck, async (req, res) => {
-    try {
-      const participant =
-        /** @type { ReturnType<typeof makeTestnetParticipant> } */ (req.user);
-      const policy = await participant.uploadPolicy(
-        new Date(clock()),
-        Site.uploadSuccessURL(base, req.protocol, req.hostname),
-      );
-      const files = await participant.myFiles();
-      const page = Site.uploadSlog(participant.member, policy, files);
-      res.send(page);
-    } catch (err) {
-      handleError(res, req.baseUrl, err);
-    }
-  });
+  app.get(
+    `${Site.path.uploadSlog}disabled@@@`,
+    loginCheck,
+    async (req, res) => {
+      try {
+        const participant =
+          /** @type { ReturnType<typeof makeTestnetParticipant> } */ (req.user);
+        const policy = await participant.uploadPolicy(
+          new Date(clock()),
+          Site.uploadSuccessURL(base, req.protocol, req.hostname),
+        );
+        const files = await participant.myFiles();
+        const page = Site.uploadSlog(participant.member, policy, files);
+        res.send(page);
+      } catch (err) {
+        handleError(res, req.baseUrl, err);
+      }
+    },
+  );
   app.get(Site.path.uploadSuccess, loginCheck, async (req, res) => {
     const participant =
       /** @type { ReturnType<typeof makeTestnetParticipant> } */ (req.user);
@@ -487,6 +591,8 @@ if (require.main === module) {
         require('@google-cloud/storage').Storage,
       ),
       admin: require('firebase-admin'),
+      // eslint-disable-next-line global-require
+      GoogleSpreadsheet: require('google-spreadsheet').GoogleSpreadsheet,
     },
   ).catch(err => console.error(err));
 }

--- a/subm/src/subm.js
+++ b/subm/src/subm.js
@@ -526,11 +526,7 @@ async function main(
     const contact = /** @type { ReturnType<typeof makeContact> } */ (req.user);
     const { user } = contact.member;
     if (!user) throw Error('no user');
-    const detail = await discordAPI.users(user.id);
-    let email = detail.email; // ISSUE: why is email missing? what bot permission am I missing?
-    if (!email) {
-      email = await contact.getEmail();
-    }
+    const email = await contact.getEmail();
     const page = Site.contactForm(contact.member, email, req.query.ack === '1');
     res.send(page);
   });

--- a/subm/src/subm.js
+++ b/subm/src/subm.js
@@ -144,8 +144,9 @@ const Site = freeze({
   /**
    * @param { GuildMember } member
    * @param { string | undefined } email
+   * @param { boolean } ack
    */
-  contactForm: (member, email) => `${AgoricStyle.top}
+  contactForm: (member, email, ack) => `${AgoricStyle.top}
 
 <h1>Contact Info</h1>
 
@@ -157,6 +158,7 @@ ${Site.welcome(member)}
      value="${email || ''}"/></label>
     <input type="submit" value="Submit">
   </fieldset>
+  ${ack ? `<p><b>Contact info updated. Thank you.</b></p>` : ''}
 </form>
   `,
   /**
@@ -529,7 +531,7 @@ async function main(
     if (!email) {
       email = await contact.getEmail();
     }
-    const page = Site.contactForm(contact.member, email);
+    const page = Site.contactForm(contact.member, email, req.query.ack === '1');
     res.send(page);
   });
   app.post(Site.path.contactForm, loginCheck, async (req, res) => {
@@ -537,7 +539,7 @@ async function main(
     const { email } = req.body;
     if (typeof email !== 'string') throw TypeError(email);
     await contact.setEmail(email);
-    res.redirect(Site.path.contactForm);
+    res.redirect(`${Site.path.contactForm}?ack=1`);
   });
 
   // Upload form

--- a/subm/yarn.lock
+++ b/subm/yarn.lock
@@ -657,6 +657,13 @@ async-retry@^1.3.1:
   dependencies:
     retry "0.13.1"
 
+axios@^0.21.4:
+  version "0.21.4"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.4.tgz#c67b90dc0568e5c1cf2b0b858c43ba28e2eda575"
+  integrity sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==
+  dependencies:
+    follow-redirects "^1.14.0"
+
 balanced-match@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
@@ -1444,6 +1451,11 @@ flatted@^3.1.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.2.tgz#64bfed5cb68fe3ca78b3eb214ad97b63bedce561"
   integrity sha512-JaTY/wtrcSyvXJl4IMFHPKyFur1sE9AUqc0QnhOaJ0CxHtAoIV8pYDzeEfAaNEtGkOfq4gr3LBFmdXW5mOQFnA==
 
+follow-redirects@^1.14.0:
+  version "1.14.6"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.6.tgz#8cfb281bbc035b3c067d6cd975b0f6ade6e855cd"
+  integrity sha512-fhUl5EwSJbbl8AR+uYL2KQDxLkdSjZGR36xy46AO7cOMTrCMON6Sa28FmAnC2tRTDbd/Uuzz3aJBv7EBN7JH8A==
+
 forwarded@0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.2.0.tgz#2269936428aad4c15c7ebe9779a84bf0b2a81811"
@@ -1558,6 +1570,21 @@ globby@^11.0.3:
     merge2 "^1.3.0"
     slash "^3.0.0"
 
+google-auth-library@^6.1.3:
+  version "6.1.6"
+  resolved "https://registry.yarnpkg.com/google-auth-library/-/google-auth-library-6.1.6.tgz#deacdcdb883d9ed6bac78bb5d79a078877fdf572"
+  integrity sha512-Q+ZjUEvLQj/lrVHF/IQwRo6p3s8Nc44Zk/DALsN+ac3T4HY/g/3rrufkgtl+nZ1TW7DNAw5cTChdVp4apUXVgQ==
+  dependencies:
+    arrify "^2.0.0"
+    base64-js "^1.3.0"
+    ecdsa-sig-formatter "^1.0.11"
+    fast-text-encoding "^1.0.0"
+    gaxios "^4.0.0"
+    gcp-metadata "^4.2.0"
+    gtoken "^5.0.4"
+    jws "^4.0.0"
+    lru-cache "^6.0.0"
+
 google-auth-library@^7.0.0, google-auth-library@^7.0.2:
   version "7.6.2"
   resolved "https://registry.yarnpkg.com/google-auth-library/-/google-auth-library-7.6.2.tgz#8654985dbd06d8519f09c9c2318c4092f289a501"
@@ -1613,6 +1640,15 @@ google-p12-pem@^3.0.3:
   integrity sha512-tjf3IQIt7tWCDsa0ofDQ1qqSCNzahXDxdAGJDbruWqu3eCg5CKLYKN+hi0s6lfvzYZ1GDVr+oDF9OOWlDSdf0A==
   dependencies:
     node-forge "^0.10.0"
+
+google-spreadsheet@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/google-spreadsheet/-/google-spreadsheet-3.2.0.tgz#ce8aa75c15705aa950ad52b091a6fc4d33dcb329"
+  integrity sha512-z7XMaqb+26rdo8p51r5O03u8aPLAPzn5YhOXYJPcf2hdMVr0dUbIARgdkRdmGiBeoV/QoU/7VNhq1MMCLZv3kQ==
+  dependencies:
+    axios "^0.21.4"
+    google-auth-library "^6.1.3"
+    lodash "^4.17.21"
 
 graceful-fs@^4.1.2:
   version "4.2.8"


### PR DESCRIPTION
BREAKING CHANGE: disables submission of slogfiles by testnet participants

 - [x] feedback on POST
 - [ ] other fields?

cc @dtribble 

tab dump, for my reference:
 - [Array.prototype.findIndex() - JavaScript | MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/findIndex)
 - [google-spreadsheet - npm](https://www.npmjs.com/package/google-spreadsheet)
   - [GoogleSpreadsheetWorksheet getrows](https://theoephraim.github.io/node-google-spreadsheet/#/classes/google-spreadsheet-worksheet?id=fn-getrows)
 - [GridRange  |  Sheets API  |  Google Developers](https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets/other#GridRange)
 - [Discord Developer Portal — Documentation — OAuth2](https://discord.com/developers/docs/topics/oauth2#bots)
 - road not taken:
   - [Inserting, updating, and deleting data using Data Manipulation Language  |  Cloud Spanner  |  Google Cloud](https://cloud.google.com/spanner/docs/dml-tasks#node.js)
